### PR TITLE
Fix: Month picker default selected to be MM 

### DIFF
--- a/src/components/month-picker.tsx
+++ b/src/components/month-picker.tsx
@@ -30,7 +30,7 @@ const MonthPicker: React.FC<IMonthPicker> = ({
 
     const monthOptions: JSX.Element[] = [];
     monthOptions.push(
-      <option value={-1} key={-1} disabled className={optionClass}>
+      <option value={-1} key={-1} disabled selected className={optionClass}>
         {placeholder ? placeholder : ""}
       </option>
     );


### PR DESCRIPTION
## Issue: 
- the month picker's default value was not MM as it was missing the `selected` property on the option

## Solution:
- added selected property in accordance with YearPicker and DayPicker